### PR TITLE
Skip auth mode, fix reload spinner, bypass Clerk for UI preview

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -41,6 +41,10 @@ export default function SignInScreen() {
   const { isLoaded, signIn, setActive } = useSignIn();
   const { startGoogleAuthenticationFlow } = useSignInWithGoogle();
   const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    console.log("[SignInScreen] mounted isLoaded=", isLoaded);
+  }, [isLoaded]);
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -23,6 +23,7 @@ import { useSubscriptions } from "../../hooks/useSubscriptions";
 import { useGroupsSummary } from "../../hooks/useGroups";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL || "https://coconut-lemon.vercel.app";
+const SKIP_AUTH = process.env.EXPO_PUBLIC_SKIP_AUTH === "true";
 
 const MERCHANT_COLORS = [
   "#E50914", "#1DB954", "#00674B", "#FF9900", "#003366", "#7BB848",
@@ -130,22 +131,20 @@ export default function HomeScreen() {
   const [signOutError, setSignOutError] = useState<string | null>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [showFabMenu, setShowFabMenu] = useState(false);
-  const [loadingTooLong, setLoadingTooLong] = useState(false);
   const isFocused = useIsFocused();
   const prevFocused = useRef(false);
 
   useEffect(() => {
-    if (!isFocused) setShowFabMenu(false);
-  }, [isFocused]);
+    console.log("[HomeScreen] mounted loading=", loading, "linked=", linked);
+  }, []);
 
   useEffect(() => {
-    if (!loading) {
-      setLoadingTooLong(false);
-      return;
-    }
-    const timer = setTimeout(() => setLoadingTooLong(true), 9000);
-    return () => clearTimeout(timer);
-  }, [loading]);
+    console.log("[HomeScreen] loading=", loading, "linked=", linked);
+  }, [loading, linked]);
+
+  useEffect(() => {
+    if (!isFocused) setShowFabMenu(false);
+  }, [isFocused]);
 
   // Refetch when returning to this tab (e.g. from connected screen after bank link)
   useEffect(() => {
@@ -206,8 +205,8 @@ export default function HomeScreen() {
     }
   };
 
-  // Auto-redirect to sign-up when auth is loaded but user is not signed in
-  if (authLoaded && !isSignedIn) {
+  // Auto-redirect to sign-up when auth is loaded but user is not signed in (skip when SKIP_AUTH)
+  if (!SKIP_AUTH && authLoaded && !isSignedIn) {
     return <Redirect href="/(auth)/sign-up" />;
   }
 
@@ -265,46 +264,13 @@ export default function HomeScreen() {
     }
   };
 
-  if (loading && !loadingTooLong) {
-    return (
-      <View style={[styles.container, styles.center, { padding: 24 }]}>
-        <ActivityIndicator size="large" color="#3D8E62" />
-        <Text style={styles.loadingText}>Loading...</Text>
-        <TouchableOpacity
-          onPress={handleSignOut}
-          style={{
-            marginTop: 24,
-            paddingVertical: 14,
-            paddingHorizontal: 32,
-            borderRadius: 12,
-            borderWidth: 2,
-            borderColor: "#3D8E62",
-          }}
-        >
-          <Text style={{ color: "#3D8E62", fontWeight: "700", fontSize: 17 }}>Sign out</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={() => Linking.openURL(webLoginUrl)}
-          style={{
-            marginTop: 16,
-            backgroundColor: "#3D8E62",
-            paddingVertical: 16,
-            paddingHorizontal: 32,
-            borderRadius: 12,
-          }}
-        >
-          <Text style={{ color: "#fff", fontWeight: "700", fontSize: 17 }}>Open login in browser</Text>
-        </TouchableOpacity>
-      </View>
-    );
-  }
-
-  if (loading && loadingTooLong) {
+  // Never show a full-screen spinner — show Connect UI with sign out / refresh options
+  if (loading) {
     return (
       <SafeAreaView style={styles.container} edges={["top"]}>
         <View style={[styles.connectCard, { padding: 24 }]}>
           <Ionicons name="time-outline" size={44} color="#3D8E62" />
-          <Text style={styles.connectTitle}>Still loading</Text>
+          <Text style={styles.connectTitle}>Checking status…</Text>
           <Text style={styles.connectSubtitle}>
             Tap below to sign out or open the web app.
           </Text>
@@ -322,10 +288,7 @@ export default function HomeScreen() {
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.connectRefreshButton}
-            onPress={() => {
-              setLoadingTooLong(false);
-              refetch(false);
-            }}
+            onPress={() => refetch(false)}
           >
             <Ionicons name="refresh" size={16} color="#3D8E62" />
             <Text style={styles.connectRefreshText}>Retry</Text>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { View, Text, TouchableOpacity, ActivityIndicator, Linking } from "react-native";
+import { useEffect, useMemo, useRef } from "react";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { ClerkProvider, useAuth, useClerk } from "@clerk/expo";
@@ -46,11 +45,11 @@ function TerminalTokenProvider({ children }: { children: React.ReactElement | Re
 }
 
 const FORCE_SIGN_OUT_ON_LAUNCH = process.env.EXPO_PUBLIC_FORCE_SIGN_OUT === "true";
+const SKIP_AUTH = process.env.EXPO_PUBLIC_SKIP_AUTH === "true";
 
 function AuthSwitch() {
   const { isSignedIn, isLoaded } = useAuth();
   const { signOut } = useClerk();
-  const [timedOut, setTimedOut] = useState(false);
   const hasClearedSession = useRef(false);
   const instance = useMemo(() => {
     if (!publishableKey) return "missing";
@@ -60,82 +59,23 @@ function AuthSwitch() {
   }, []);
 
   useEffect(() => {
-    if (isLoaded) {
-      setTimedOut(false);
-      return;
-    }
-    const t = setTimeout(() => setTimedOut(true), 8000);
-    return () => clearTimeout(t);
-  }, [isLoaded]);
-
-  useEffect(() => {
-    console.log(`[auth] isLoaded=${String(isLoaded)} isSignedIn=${String(isSignedIn)} instance=${instance}`);
+    if (SKIP_AUTH) return;
+    const showAuth = !isLoaded || !isSignedIn || (FORCE_SIGN_OUT_ON_LAUNCH && isSignedIn);
+    console.log(`[AuthSwitch] isLoaded=${isLoaded} isSignedIn=${isSignedIn} FORCE_SIGN_OUT=${FORCE_SIGN_OUT_ON_LAUNCH} → ${showAuth ? "AUTH" : "TABS"}`);
   }, [isLoaded, isSignedIn, instance]);
 
   // Clear stale cached session that causes sign-in → tabs → forever-spinner loop
   useEffect(() => {
-    if (!FORCE_SIGN_OUT_ON_LAUNCH || !isLoaded || !isSignedIn || hasClearedSession.current) return;
+    if (SKIP_AUTH || !FORCE_SIGN_OUT_ON_LAUNCH || !isLoaded || !isSignedIn || hasClearedSession.current) return;
+    console.log("[AuthSwitch] FORCE_SIGN_OUT: calling signOut()...");
     hasClearedSession.current = true;
-    signOut?.().catch((e: unknown) => console.warn("[auth] force sign-out failed:", e));
+    signOut?.()
+      .then(() => console.log("[AuthSwitch] FORCE_SIGN_OUT: signOut() done"))
+      .catch((e: unknown) => console.warn("[AuthSwitch] FORCE_SIGN_OUT failed:", e));
   }, [isLoaded, isSignedIn, signOut]);
 
-  if (!isLoaded && !timedOut) {
-    const webLoginUrl = `${API_URL.replace(/\/$/, "")}/login`;
-    return (
-      <View style={{ flex: 1, backgroundColor: "#fff", alignItems: "center", justifyContent: "center", padding: 24 }}>
-        <ActivityIndicator size="large" color="#3D8E62" />
-        <Text style={{ marginTop: 12, color: "#6B7280", fontSize: 14 }}>Initializing auth...</Text>
-        <TouchableOpacity
-          onPress={() => Linking.openURL(webLoginUrl)}
-          style={{
-            marginTop: 24,
-            backgroundColor: "#3D8E62",
-            paddingVertical: 14,
-            paddingHorizontal: 24,
-            borderRadius: 12,
-          }}
-        >
-          <Text style={{ color: "#fff", fontWeight: "600", fontSize: 16 }}>Open login in browser</Text>
-        </TouchableOpacity>
-      </View>
-    );
-  }
-  if (!isLoaded && timedOut) {
-    const webLoginUrl = `${API_URL.replace(/\/$/, "")}/login`;
-    return (
-      <View style={{ flex: 1, backgroundColor: "#fff", alignItems: "center", justifyContent: "center", padding: 24 }}>
-        <Text style={{ fontSize: 20, fontWeight: "700", color: "#1F2937", marginBottom: 8 }}>Auth stuck loading</Text>
-        <Text style={{ color: "#6B7280", textAlign: "center", lineHeight: 20 }}>
-          Clerk did not finish initialization on this device.
-        </Text>
-        <Text style={{ color: "#9CA3AF", textAlign: "center", marginTop: 10, fontSize: 12 }}>
-          instance: {instance}
-        </Text>
-        <Text style={{ color: "#9CA3AF", textAlign: "center", marginTop: 4, fontSize: 12 }}>
-          key present: {String(Boolean(publishableKey))}
-        </Text>
-        <TouchableOpacity
-          onPress={() => Linking.openURL(webLoginUrl)}
-          style={{
-            marginTop: 18,
-            backgroundColor: "#3D8E62",
-            paddingVertical: 12,
-            paddingHorizontal: 18,
-            borderRadius: 10,
-          }}
-        >
-          <Text style={{ color: "#fff", fontWeight: "600" }}>Open login in browser</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={() => setTimedOut(false)}
-          style={{ marginTop: 12 }}
-        >
-          <Text style={{ color: "#3D8E62", fontWeight: "500" }}>Retry auth init</Text>
-        </TouchableOpacity>
-      </View>
-    );
-  }
-  if (isSignedIn) {
+  // SKIP_AUTH: always show tabs so you can see the UI without signing in
+  if (SKIP_AUTH) {
     return (
       <TerminalTokenProvider>
         <Stack screenOptions={{ headerShown: false }}>
@@ -145,10 +85,22 @@ function AuthSwitch() {
       </TerminalTokenProvider>
     );
   }
+
+  // Block tabs when: not loaded, not signed in, OR FORCE_SIGN_OUT + cached session (until signOut completes)
+  if (!isLoaded || !isSignedIn || (FORCE_SIGN_OUT_ON_LAUNCH && isSignedIn)) {
+    return (
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+      </Stack>
+    );
+  }
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-    </Stack>
+    <TerminalTokenProvider>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="connected" options={{ headerShown: false }} />
+      </Stack>
+    </TerminalTokenProvider>
   );
 }
 
@@ -156,7 +108,7 @@ export default function RootLayout() {
   return (
     <ClerkProvider
       publishableKey={publishableKey ?? ""}
-      tokenCache={tokenCache}
+      tokenCache={SKIP_AUTH || FORCE_SIGN_OUT_ON_LAUNCH ? undefined : tokenCache}
     >
       <StatusBar style="auto" />
       <AuthSwitch />

--- a/hooks/useTransactions.ts
+++ b/hooks/useTransactions.ts
@@ -29,8 +29,9 @@ export function useTransactions() {
 
   const fetchData = useCallback((silent = false): Promise<void> => {
     let cancelled = false;
-    setStatus("ok");
     const isFirstLoad = !hasShownInitialLoad.current;
+    console.log(`[useTransactions] fetchData started silent=${silent} isFirstLoad=${isFirstLoad}`);
+    setStatus("ok");
     if (!silent && isFirstLoad) setLoading(true);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10000);
@@ -38,15 +39,17 @@ export function useTransactions() {
       .then((r) => {
         clearTimeout(timeout);
         if (cancelled) return null;
+        console.log(`[useTransactions] plaid/status → ${r.status}`);
         if (r.status === 425) {
-          // Clerk token warming up: retry silently a few times instead of showing "Connect bank".
           if (transientRetryCount.current < 8) {
             transientRetryCount.current += 1;
+            console.log(`[useTransactions] 425 retry ${transientRetryCount.current}/8`);
             setTimeout(() => {
               if (!cancelled) fetchData(true);
             }, 800);
             return null;
           }
+          console.log("[useTransactions] 425 max retries, setting loading=false");
           setLoading(false);
           return null;
         }
@@ -66,10 +69,12 @@ export function useTransactions() {
       .then((data) => {
         if (cancelled || !data) return null;
         if (!data.linked) {
+          console.log("[useTransactions] not linked, loading=false");
           setStatus("not_linked");
           setLoading(false);
           return null;
         }
+        console.log("[useTransactions] linked! fetching transactions");
         setLinked(true);
         return apiFetch("/api/plaid/transactions");
       })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,15 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useAuth } from "@clerk/expo";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL || "https://coconut-lemon.vercel.app";
+const SKIP_AUTH = process.env.EXPO_PUBLIC_SKIP_AUTH === "true";
+
+function unauthResponse() {
+  return new Response(JSON.stringify({ error: "Unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json", "X-Coconut-Auth": "signed-out" },
+  });
+}
 
 /** Clerk has a race: getToken() can return null right after isSignedIn. Retry a few times. */
 async function getTokenWithRetry(
@@ -20,41 +28,24 @@ async function getTokenWithRetry(
 
 export function useApiFetch() {
   const { getToken, isLoaded, isSignedIn } = useAuth();
+  const ref = useRef({ getToken, isLoaded, isSignedIn });
+  ref.current = { getToken, isLoaded, isSignedIn };
 
   return useCallback(
     async (
       path: string,
       opts: Omit<RequestInit, "body"> & { body?: object | FormData } = {}
     ) => {
-      // Signed-out state: return synthetic 401 (no network request).
-      if (isLoaded && !isSignedIn) {
-        return new Response(
-          JSON.stringify({ error: "Unauthorized" }),
-          {
-            status: 401,
-            headers: {
-              "Content-Type": "application/json",
-              "X-Coconut-Auth": "signed-out",
-            },
-          }
-        );
-      }
+      // SKIP_AUTH: never wait for token, return 401 so UI shows Connect state immediately
+      if (SKIP_AUTH) return unauthResponse();
 
-      const token = await getTokenWithRetry(getToken);
+      const { isLoaded: loaded, isSignedIn: signedIn, getToken: gt } = ref.current;
+      console.log(`[apiFetch] ${path} loaded=${loaded} signedIn=${signedIn}`);
+      if (loaded && !signedIn) return unauthResponse();
+
+      const token = await getTokenWithRetry(gt);
       if (!token) {
-        // If auth is fully loaded and signed out, keep status semantics consistent.
-        if (isLoaded && !isSignedIn) {
-          return new Response(
-            JSON.stringify({ error: "Unauthorized" }),
-            {
-              status: 401,
-              headers: {
-                "Content-Type": "application/json",
-                "X-Coconut-Auth": "signed-out",
-              },
-            }
-          );
-        }
+        if (loaded && !signedIn) return unauthResponse();
         // Token race window: don't hit backend unauthenticated.
         return new Response(
           JSON.stringify({ error: "Session token unavailable" }),
@@ -90,7 +81,7 @@ export function useApiFetch() {
       }
       return fetch(url, { ...opts, headers, body });
     },
-    [getToken, isLoaded, isSignedIn]
+    []
   );
 }
 


### PR DESCRIPTION
## Changes
- **SKIP_AUTH mode**: Set `EXPO_PUBLIC_SKIP_AUTH=true` to bypass Clerk and view the app UI without signing in
- **API short-circuit**: When SKIP_AUTH, return 401 immediately so Connect UI shows instead of loading spinner
- **No full-screen spinner**: Home loading state shows "Checking status…" with Sign out / Retry buttons instead of spinner
- **Auth layout**: FORCE_SIGN_OUT and SKIP_AUTH flags for debugging auth flow

Made with [Cursor](https://cursor.com)