### PR TITLE
fix: bug council audit (mobile) — 5 bugs fixed

### DIFF
--- a/.cursor/rules/common-bugs.mdc
+++ b/.cursor/rules/common-bugs.mdc
@@ -1,0 +1,25 @@
+---
+description: Common bug patterns discovered by Bug Council audits. Follow these to avoid recurring issues.
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
+---
+
+# Common Bug Patterns
+
+## Network / API
+- Always check `res.ok` BEFORE calling `res.json()` — error responses may return non-JSON (HTML, plain text). Use `res.json().catch(() => ({}))` for safe error-body extraction.
+- Always capture and check the return value of `apiFetch` — never `await apiFetch(...)` without checking `.ok`. Silent API failures cause data to appear saved when it wasn't.
+- Always use `try-catch-finally`, not `try-finally` — a bare `try-finally` swallows errors from the try block and gives users no feedback.
+
+## Payments
+- Stripe Terminal requires amounts in **cents** (integer). Always convert: `Math.round(amountInDollars * 100)`. Never send a raw dollar float.
+
+## Auth / Timeouts
+- Apply `withTimeout()` to ALL Clerk async operations on EVERY auth screen — sign-in and sign-up must have parity. Missing timeout = infinite spinner on slow networks.
+- When wrapping Clerk calls in `withTimeout<T>()`, the broken Clerk type causes T to infer as `unknown`. Cast the result explicitly: `as { status?: string; createdSessionId?: string }`.
+- After retrying `getToken()`, throw early if token is still null — never send `Authorization: ""`. Empty auth headers cause 401s that are harder to diagnose than an explicit throw.
+
+## Loading State
+- Call `setLoading(false)` in a `finally` block unconditionally — never gate it on flags or only in the catch branch.
+- Set guard flags (`hasClearedSession`, etc.) BEFORE the async call to prevent re-entry, but handle the error if the call fails.

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -112,7 +112,7 @@ export default function SignUpScreen() {
         signUp.attemptEmailAddressVerification({ code }),
         SIGN_UP_TIMEOUT_MS,
         "Email verification"
-      );
+      ) as { status?: string; createdSessionId?: string };
       if (result.status === "complete" && result.createdSessionId) {
         await withTimeout(
           setActive({ session: result.createdSessionId }),

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -19,6 +19,22 @@ function getClerkErrorMessage(e: unknown, fallback: string): string {
   return first?.longMessage || first?.message || err?.message || fallback;
 }
 
+const SIGN_UP_TIMEOUT_MS = 20000;
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 export default function SignUpScreen() {
   const { isLoaded, signUp, setActive } = useSignUp();
   const { startGoogleAuthenticationFlow } = useSignInWithGoogle();
@@ -35,9 +51,17 @@ export default function SignUpScreen() {
     setError("");
     setGoogleLoading(true);
     try {
-      const { createdSessionId, setActive } = await startGoogleAuthenticationFlow();
+      const { createdSessionId, setActive } = await withTimeout(
+        startGoogleAuthenticationFlow(),
+        SIGN_UP_TIMEOUT_MS,
+        "Google auth flow"
+      );
       if (createdSessionId && setActive) {
-        await setActive({ session: createdSessionId });
+        await withTimeout(
+          setActive({ session: createdSessionId }),
+          SIGN_UP_TIMEOUT_MS,
+          "Google setActive"
+        );
       }
     } catch (e: unknown) {
       const err = e as { code?: string; message?: string };
@@ -61,8 +85,16 @@ export default function SignUpScreen() {
     setError("");
     setLoading(true);
     try {
-      await signUp.create({ emailAddress: email, password });
-      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+      await withTimeout(
+        signUp.create({ emailAddress: email, password }),
+        SIGN_UP_TIMEOUT_MS,
+        "Sign-up create"
+      );
+      await withTimeout(
+        signUp.prepareEmailAddressVerification({ strategy: "email_code" }),
+        SIGN_UP_TIMEOUT_MS,
+        "Email verification prep"
+      );
       setPendingVerification(true);
     } catch (e: unknown) {
       setError(getClerkErrorMessage(e, "Sign up failed"));
@@ -76,9 +108,17 @@ export default function SignUpScreen() {
     setError("");
     setLoading(true);
     try {
-      const result = await signUp.attemptEmailAddressVerification({ code });
+      const result = await withTimeout(
+        signUp.attemptEmailAddressVerification({ code }),
+        SIGN_UP_TIMEOUT_MS,
+        "Email verification"
+      );
       if (result.status === "complete" && result.createdSessionId) {
-        await setActive({ session: result.createdSessionId });
+        await withTimeout(
+          setActive({ session: result.createdSessionId }),
+          SIGN_UP_TIMEOUT_MS,
+          "Verify setActive"
+        );
       } else {
         setError("Verification is not complete yet. Please try again.");
       }

--- a/app/(tabs)/pay.tsx
+++ b/app/(tabs)/pay.tsx
@@ -121,7 +121,7 @@ export default function PayScreen() {
 
     setCollecting(true);
     try {
-      const body: Record<string, unknown> = { amount: amt };
+      const body: Record<string, unknown> = { amount: Math.round(amt * 100) };
       if (params.groupId && params.payerMemberId && params.receiverMemberId) {
         body.groupId = params.groupId;
         body.payerMemberId = params.payerMemberId;

--- a/app/(tabs)/receipt.tsx
+++ b/app/(tabs)/receipt.tsx
@@ -611,7 +611,12 @@ function AssignStep({
               styles.buttonDisabled,
           ]}
           onPress={async () => {
-            await rs.saveAssignments();
+            try {
+              await rs.saveAssignments();
+            } catch (e) {
+              Alert.alert("Error", e instanceof Error ? e.message : "Failed to save assignments");
+              return;
+            }
             rs.computeSummary();
           }}
           disabled={!allAssigned || rs.people.length === 0 || rs.saving}
@@ -757,8 +762,12 @@ function SummaryStep({
           receiverMemberId: s.toMemberId,
         },
       });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(errData.error ?? "Payment link request failed");
+      }
       const data = await res.json();
-      if (res.ok && data.url) {
+      if (data.url) {
         await Share.share({
           message: `You owe me $${s.amount.toFixed(2)} for ${groupName || "our receipt split"}. Pay here: ${data.url}`,
           url: data.url,
@@ -783,6 +792,8 @@ function SummaryStep({
           );
         }
       }
+    } catch (e) {
+      Alert.alert("Error", e instanceof Error ? e.message : "Failed to request payment");
     } finally {
       setRequestingPayment(null);
     }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,15 +22,19 @@ function TerminalTokenProvider({ children }: { children: React.ReactElement | Re
       if (token) break;
       if (i < 3) await new Promise((r) => setTimeout(r, 300 * (i + 1)));
     }
+    if (!token) throw new Error("No auth token available for Stripe Terminal");
     const res = await fetch(`${API_URL.replace(/\/$/, "")}/api/stripe/terminal/connection-token`, {
       method: "POST",
       headers: {
-        Authorization: token ? `Bearer ${token}` : "",
+        Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
     });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({})) as { error?: string };
+      throw new Error(data.error ?? "Failed to get connection token");
+    }
     const data = await res.json();
-    if (!res.ok) throw new Error(data.error ?? "Failed to get connection token");
     return data.secret;
   };
 

--- a/hooks/useReceiptSplit.ts
+++ b/hooks/useReceiptSplit.ts
@@ -321,10 +321,14 @@ export function useReceiptSplit(apiFetch: ApiFetch) {
             })),
           })
         );
-        await apiFetch(`/api/receipt/${receiptId}/assign`, {
+        const res = await apiFetch(`/api/receipt/${receiptId}/assign`, {
           method: "POST",
           body: { assignments: payload },
         });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({})) as { error?: string };
+          throw new Error(data.error ?? "Failed to save assignments");
+        }
       } finally {
         setSaving(false);
       }


### PR DESCRIPTION
## Bug Council Audit Results (Mobile)

**Bugs reported by agents**: 6 (5 distinct + 1 duplicate)
**Bugs verified (survived Devil's Advocate)**: 5 (4 distinct)
**Bugs fixed**: 5
**Bugs deferred**: 0
**False positives rejected**: 0

## Fixed Bugs

### P0 — Critical
- **BUG-FLOWS-2**: Payment amount sent in dollars instead of cents — `app/(tabs)/pay.tsx`
  User entering "$10" triggered a $0.10 Stripe charge (100x undercharge). Fixed with `Math.round(amt * 100)`.

### P1 — Broken Functionality
- **BUG-NATIVE-1**: Empty Authorization header sent when Clerk token unavailable — `app/_layout.tsx`
  After 4 retries, null token caused `Authorization: ""` instead of an early throw. Also fixed `res.json()` before `res.ok` in the same function.

- **BUG-NAV_AUTH-1**: Sign-up screen had no timeout protection on any Clerk operation — `app/(auth)/sign-up.tsx`
  `sign-in.tsx` wrapped all Clerk calls in `withTimeout()`; `sign-up.tsx` had none. Slow-network users got permanent spinners. Added `withTimeout` to all 6 Clerk calls (Google auth, create, prepareVerification, attemptVerification, setActive×2).

- **BUG-API-1**: `saveAssignments()` silently swallowed API errors — `hooks/useReceiptSplit.ts` + `app/(tabs)/receipt.tsx`
  Response was never checked; if the API returned 4xx/5xx the function completed successfully and the caller proceeded to show a summary of data that was never persisted. Now checks `res.ok`, throws on error, and the caller shows an Alert.

- **BUG-FLOWS-3**: `res.json()` called before `res.ok` check in `handleRequestPayment` — `app/(tabs)/receipt.tsx`
  Non-JSON error responses (e.g. 502 HTML) caused an unhandled throw in a `try-finally` with no `catch`, silently clearing the loading state with no user feedback. Fixed: check `res.ok` first, added `catch` block with `Alert`.

## Tests Added
No automated tests added. Affected code paths require Stripe Terminal native modules, Clerk auth, or end-to-end API integration — unit tests are not practical without significant mocking infrastructure. Manual test steps documented in each commit message.

## Manual Test Plan
- **BUG-FLOWS-2**: Enter "$10" in Pay tab → complete Tap to Pay → verify Stripe dashboard shows $10.00
- **BUG-NATIVE-1**: Disable network, open Tap to Pay screen → verify error alert, not silent 401
- **BUG-NAV_AUTH-1**: Simulate slow network on sign-up → verify error shown within 20s, not infinite spinner
- **BUG-API-1**: Set network offline, assign items, tap "View Summary" → verify error alert, not summary screen
- **BUG-FLOWS-3**: Proxy `/api/stripe/create-payment-link` to return 502 → verify error alert shown

## Deferred Bugs (Not Fixed)
None.

## Disproved Bugs (Rejected by Devil's Advocate)
None — all reported bugs were verified.

## Patterns Found
- `.json()` before `.ok` — 6th consecutive audit with this pattern (receipt.tsx)
- `try-finally` without `catch` — saveAssignments, handleRequestPayment
- Payment amount unit regression — 3rd occurrence across audits
- `withTimeout` parity gap between auth screens — recurring

## Verification
- [x] `npx tsc --noEmit` — passes (8 baseline errors unchanged, 0 new errors)
- [x] `npm test` — no test runner configured (pre-existing)

---
Generated by Bug Council v2 (evidence-based, mobile)